### PR TITLE
do not deepcopy schema data

### DIFF
--- a/notario/normal.py
+++ b/notario/normal.py
@@ -1,11 +1,10 @@
-import copy
 from notario.utils import ndict, is_nested_tuple
 
 
 class BaseNormalize(object):
 
     def __init__(self, data, schema):
-        self.raw_data = copy.deepcopy(data)
+        self.raw_data = dict(data)
         self.raw_schema = schema
 
     def ordered_dict(self, data_structure, use_n_dict=False):

--- a/notario/tests/test_normal.py
+++ b/notario/tests/test_normal.py
@@ -1,3 +1,5 @@
+import re
+
 from notario import normal
 
 
@@ -21,3 +23,8 @@ class TestSchema(object):
         data = (('a', 'b'), ('b', 'b'), ('c', 'c'))
         result = normal.Schema({}, data).normalized()
         assert result == {0: ('a', 'b'), 1: ('b', 'b'), 2: ('c', 'c')}
+
+    def test_unserializable_object(self):
+        regex = re.compile(".*")
+        result = normal.Schema({"foo": regex}, ['a']).normalized()
+        assert result == {0: ['a']}


### PR DESCRIPTION
If the data contains objects that can't be copied, like a compiled
regex, then the copy.deepcopy will fail. This was noticed when trying to
validate data given to notario by Ansible. If you instead just create
another python dictionary it avoids the deepcopy issue.

See:

https://github.com/ceph/ceph-ansible/issues/2672

Signed-off-by: Andrew Schoen <aschoen@redhat.com>